### PR TITLE
Small status fix

### DIFF
--- a/lib/buildr/ivy_extension.rb
+++ b/lib/buildr/ivy_extension.rb
@@ -199,7 +199,8 @@ module Buildr
           @base_ivy.__publish__
         else
           unless @published
-            base_options = {:status => status, :pubrevision => revision, :artifactspattern => "#{publish_from}/[artifact].[ext]"}
+            base_options = {:pubrevision => revision, :artifactspattern => "#{publish_from}/[artifact].[ext]"}
+            base_options[:status] = status if status
             options = publish_options * base_options
             ivy4r.publish options
             @published = true


### PR DESCRIPTION
Hi Klaas,

Could you review this patch. If I didn't specify any particular status value I was getting delivered ivy.xml files that contained status="" which caused problems in our repository.
The patch only explicitly sets the status that is passed to publish if it is defined. I then get status="integration" which is the default value I was expecting.

Thanks,

Pepijn
