### PR TITLE
Added name for 'after_define' extension, so other extensions can have order relative to this

### DIFF
--- a/lib/buildr/ivy_extension.rb
+++ b/lib/buildr/ivy_extension.rb
@@ -700,7 +700,7 @@ For more configuration options see IvyConfig.
         end
       end
   
-      after_define do |project|
+      after_define :ivy do |project|
         if project.ivy.enabled?
           IvyExtension.add_ivy_deps_to_java_tasks(project)
           IvyExtension.add_manifest_to_distributeables(project)


### PR DESCRIPTION
Added name for 'after_define' extension, so other extensions can have order relative to this

As described in the buildr [documentation](http://buildr.apache.org/extending.html#extensions), if after_define blocks specify a name, it's possible for other extensions to define an order relative to that name.
