### PR TITLE
javadoc dependency fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== 0.12.11 / 2014-11-21
+  * Fix compatibility with MRI Ruby 2.x+
+  * Buildr: Use doc instead of javadoc to silence deprecation warnings
+
 === 0.12.10 / 2011-01-21
   * Default folder for settings file changed to '@extension_dir/iyvsettings.xml'
   * Default ivy.home property is left empty to use default '${user.home}/.ivy2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # All in gemspec
 gemspec

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 = ivy4r
 
-* http://github.com/klaas1979/ivy4r/tree/master
+* http://github.com/pepijnve/ivy4r/tree/master
 
 == DESCRIPTION:
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ begin
     t.rdoc_dir = "doc"
     t.rdoc_files.include("**/*.rdoc").include("lib/**/*.rb")
     t.options << "--line-numbers"
-    t.options << "--webcvs=http://github.com/klaas1979/ivy4r/tree/master/"
+    t.options << "--webcvs=http://github.com/pepijnve/ivy4r/tree/master/"
   end
 rescue LoadError
   puts "'gem install hanna' to generate documentation"

--- a/ivy4r.gemspec
+++ b/ivy4r.gemspec
@@ -3,12 +3,12 @@ $:.push File.expand_path("../lib", __FILE__)
 require "ivy4r/version"
 
 Gem::Specification.new do |s|
-  s.name        = "ivy4r"
+  s.name        = "pepijnve-ivy4r"
   s.version     = Ivy4r::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Klaas Reineke"]
+  s.authors     = ["Klaas Reineke", "Pepijn Van Eeckhoudt"]
   s.email       = ["klaas.reineke@googlemail.com"]
-  s.homepage    = "http://github.com/klaas1979/ivy4r"
+  s.homepage    = "http://github.com/pepijnve/ivy4r"
   s.summary     = %q{Ivy4r Apache Ivy dependency management for Ruby}
   s.description = %q{Ivy4r is a Ruby interface for Apache Ivy dependency management library. Offers support for using Ivy with Buildr and Rake.}
 

--- a/ivy4r.gemspec
+++ b/ivy4r.gemspec
@@ -19,11 +19,12 @@ Gem::Specification.new do |s|
   #s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'Antwrap', '>= 0.7.0'
-  s.add_dependency 'ivy4r-jars', '>= 1.2.0'
+  s.add_dependency 'atoulme-Antwrap', '~> 0.7.4'
+  s.add_dependency 'ivy4r-jars', '~> 1.2.0'
 
-  s.add_development_dependency 'autotest', '>=4.4.6'
-  s.add_development_dependency 'ZenTest', '>=4.4.2'
-  s.add_development_dependency 'rspec', '>= 2.4.0'
-  s.add_development_dependency 'rr', '>=1.0.2'
+  s.add_development_dependency 'rake', '~> 10.3.2'
+  s.add_development_dependency 'autotest', '~> 4.4.6'
+  s.add_development_dependency 'ZenTest', '~> 4.4.2'
+  s.add_development_dependency 'rspec', '~> 2.4.0'
+  s.add_development_dependency 'rr', '~> 1.0.2'
 end

--- a/lib/buildr/ivy_extension.rb
+++ b/lib/buildr/ivy_extension.rb
@@ -201,7 +201,7 @@ module Buildr
           unless @published
             base_options = {:pubrevision => revision, :artifactspattern => "#{publish_from}/[artifact].[ext]"}
             base_options[:status] = status if status
-            options = publish_options * base_options
+            options = base_options.merge publish_options
             ivy4r.publish options
             @published = true
           end

--- a/lib/buildr/ivy_extension.rb
+++ b/lib/buildr/ivy_extension.rb
@@ -554,14 +554,14 @@ For more configuration options see IvyConfig.
           end
           project.task "test:compile" => "#{project.name}:testdeps"
       
-          project.task :javadocdeps => resolve_target do
+          project.task :docdeps => resolve_target do
             confs = [project.ivy.test_conf, project.ivy.compile_conf].flatten.uniq
             if deps = project.ivy.deps(confs)
-              project.javadoc.with deps
-              info "Ivy adding javadoc dependencies '#{confs.join(', ')}' to project '#{project.name}'"
+              project.doc.with deps
+              info "Ivy adding doc dependencies '#{confs.join(', ')}' to project '#{project.name}'"
             end
           end
-          project.task :javadoc => "#{project.name}:javadocdeps"
+          project.doc.enhance( ["#{project.name}:docdeps"] )
       
           [project.task(:eclipse), project.task(:idea), project.task(:idea7x)].each do |task|
             [task, task.prerequisites].flatten.each{|p| p.enhance ["#{project.name}:compiledeps", "#{project.name}:testdeps"]}

--- a/lib/ivy/java/java_object_wrapper.rb
+++ b/lib/ivy/java/java_object_wrapper.rb
@@ -93,7 +93,7 @@ module Rjb
       def find_converter(object)
         classnames_to_check(object).each do |name|
           wrapper = wrapper_name(name)
-          if respond_to? wrapper
+          if respond_to?(wrapper, true)
             return send(wrapper, object)
           end
         end

--- a/lib/ivy/target.rb
+++ b/lib/ivy/target.rb
@@ -89,7 +89,7 @@ module Ivy
             if params.member? :nested
               p = params.dup
               nest = p.delete(:nested)
-              @ant.send(method, p, &lambda {call_nested(nest)})
+              @ant.send(method, p, &lambda { |*_| call_nested(nest)})
             else
               @ant.send(method, params)
             end

--- a/lib/ivy4r/version.rb
+++ b/lib/ivy4r/version.rb
@@ -1,3 +1,3 @@
 class Ivy4r
-  VERSION = "0.12.10"
+  VERSION = "0.12.11"
 end


### PR DESCRIPTION
Hi Klaas,

add_ivy_deps_to_java_tasks in 0.12.10 adds the test and compile dependencies to the javadoc task. That task is deprecated though and has been replaced with the more general purpose doc task. This can cause incorrect builds in some cases. This change simply replaces javadoc with doc.

Pepijn
