### PR TITLE
Pass true to respond_to? to pick up protected methods.

### DIFF
--- a/lib/ivy/java/java_object_wrapper.rb
+++ b/lib/ivy/java/java_object_wrapper.rb
@@ -93,7 +93,7 @@ module Rjb
       def find_converter(object)
         classnames_to_check(object).each do |name|
           wrapper = wrapper_name(name)
-          if respond_to? wrapper
+          if respond_to?(wrapper, true)
             return send(wrapper, object)
           end
         end


### PR DESCRIPTION
In Ruby 2.0, respond_to? ignores both private and protected methods (in Ruby 1.x, it only ignored private methods).

This broke ivy4r's Java wrapper logic since the converter methods are protected. In Ruby 2.0, they would not be discovered, and code that later assumed a j.u.HashMap had become a Hash would fail.

Tangentially, I tried to run the tests, but am getting a slew of failures. Not sure if that's expected or not.
